### PR TITLE
Boot address + Questasim Compilation Fix

### DIFF
--- a/hw/occamy/occamy_quadrant_s1.sv.tpl
+++ b/hw/occamy/occamy_quadrant_s1.sv.tpl
@@ -238,6 +238,8 @@ module ${name}_quadrant_s1
     .msip_i (msip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
     .hart_base_id_i (hart_base_id_${i}),
     .cluster_base_addr_i (cluster_base_addr[${i}]),
+    // Boot Address is fixed to 0x100_0000 for now
+    .boot_addr_i (32'h0100_0000), 
     .narrow_in_req_i (${narrow_cluster_in.req_name()}),
     .narrow_in_resp_o (${narrow_cluster_in.rsp_name()}),
     .narrow_out_req_o  (${narrow_cluster_out.req_name()}),

--- a/target/sim/Makefile
+++ b/target/sim/Makefile
@@ -137,7 +137,7 @@ TB_CC_SOURCES += $(TARGET_TEST_DIR)/uartdpi/uartdpi.c
 
 FESVR = $(SIM_MKFILE_DIR)/work
 
-TB_CC_FLAGS  = -std=c++14
+TB_CC_FLAGS  = -std=c++17
 TB_CC_FLAGS +=-I$(SIM_MKFILE_DIR)
 TB_CC_FLAGS +=-I$(SIM_MKFILE_DIR)/test
 TB_CC_FLAGS +=-I$(FESVR)/include
@@ -329,7 +329,7 @@ $(VLT_BUILDDIR)/test/uartdpi/uartdpi.o: test/uartdpi/uartdpi.c
 # Link verilated archive wich $(VLT_COBJ)
 $(BIN_DIR)/$(TARGET).vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
-	$(CXX) $(LDFLAGS) -std=c++14 -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lfesvr -lpthread -lutil
+	$(CXX) $(LDFLAGS) -std=c++17 -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lfesvr -lpthread -lutil
 
 # Clean all build directories and temporary files for Verilator simulation
 .PHONY: clean-vlt


### PR DESCRIPTION
This PR fixes errors when snitch's boot address is not driven when integrating with Occammy by always setting the Boot address to 0x100_0000. Furthermore, it modifies the C++ version so that Questasim can compile successfully. 